### PR TITLE
rename email.Utils to email.utils

### DIFF
--- a/bin/csv2vcd
+++ b/bin/csv2vcd
@@ -18,7 +18,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from email.Utils import formatdate
+from email.utils import formatdate
 from os.path import isfile, exists, basename, splitext
 import sys
 

--- a/bin/csv2vcd.real
+++ b/bin/csv2vcd.real
@@ -18,7 +18,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from email.Utils import formatdate
+from email.utils import formatdate
 from os.path import isfile, exists, basename, splitext
 import sys
 

--- a/bin/csv2vcd.vector
+++ b/bin/csv2vcd.vector
@@ -18,7 +18,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from email.Utils import formatdate
+from email.utils import formatdate
 from os.path import isfile, exists, basename, splitext
 import sys
 


### PR DESCRIPTION

```bash
> python 
Python 3.9.6 (default, Jun 30 2021, 10:22:16) 
[GCC 11.1.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from email.Utils import formatdate
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'email.Utils'
>>>
>>> from email.utils import formatdate
>>>     
```